### PR TITLE
chore(pom): remove redundant tags

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -9,22 +9,6 @@
   <artifactId>bonita-project-assemblies</artifactId>
   <name>Bonita Project assemblies</name>
   <description>This module contains Bonita project specific assemblies</description>
-  <url>https://www.bonitasoft.com</url>
-  <developers>
-    <developer>
-      <id>bonitasoft</id>
-      <name>Bonitasoft</name>
-      <email>rd.user@bonitasoft.com</email>
-      <organization>Bonitasoft</organization>
-      <organizationUrl>https://www.bonitasoft.com</organizationUrl>
-    </developer>
-  </developers>
-  <scm>
-    <connection>scm:git:git@github.com:bonitasoft/bonita-project.git</connection>
-    <developerConnection>scm:git:git@github.com:bonitasoft/bonita-project.git</developerConnection>
-    <tag>HEAD</tag>
-    <url>https://github.com/bonitasoft/bonita-project</url>
-  </scm>
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -10,22 +10,6 @@
   <packaging>pom</packaging>
   <name>Bonita Project Parent pom</name>
   <description>A parent pom used for Bonita Project.</description>
-  <url>https://www.bonitasoft.com</url>
-  <developers>
-    <developer>
-      <id>bonitasoft</id>
-      <name>Bonitasoft</name>
-      <email>rd.user@bonitasoft.com</email>
-      <organization>Bonitasoft</organization>
-      <organizationUrl>https://www.bonitasoft.com</organizationUrl>
-    </developer>
-  </developers>
-  <scm>
-    <connection>scm:git:git@github.com:bonitasoft/bonita-project.git</connection>
-    <developerConnection>scm:git:git@github.com:bonitasoft/bonita-project.git</developerConnection>
-    <tag>HEAD</tag>
-    <url>https://github.com/bonitasoft/bonita-project</url>
-  </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" child.project.url.inherit.append.path="false" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.bonitasoft</groupId>
   <artifactId>bonita-project-parent</artifactId>
@@ -195,6 +195,9 @@
               <updatePomFile>true</updatePomFile>
               <pomElements>
                 <parent>remove</parent>
+                <url>expand</url>
+                <scm>expand</scm>
+                <developers>expand</developers>
               </pomElements>
               <keepCommentsInPom>true</keepCommentsInPom>
             </configuration>


### PR DESCRIPTION
ossrh POM elements like `url`, `scm` and `developers` can be removed and expanded from the parent POM.