### PR TITLE
feat(classpath): Build and include webapp classpath

### DIFF
--- a/assemblies/src/main/resources/assemblies/bundle-tomcat-assembly.xml
+++ b/assemblies/src/main/resources/assemblies/bundle-tomcat-assembly.xml
@@ -10,17 +10,15 @@
         <fileSet>
             <directory>${project.build.directory}/bundle</directory>
             <outputDirectory>.</outputDirectory>
-            <excludes>
-                <exclude>BonitaCommunity-${branding.version}/setup/platform_conf/initial/platform_engine/bonita-platform-community-custom.properties</exclude>
-            </excludes>
         </fileSet>
         <fileSet>
-            <directory>${project.build.directory}/bundle</directory>
-            <outputDirectory>.</outputDirectory>
-            <filtered>true</filtered>
+            <directory>${project.build.directory}/classpath</directory>
             <includes>
-                <include>BonitaCommunity-${branding.version}/setup/platform_conf/initial/platform_engine/bonita-platform-community-custom.properties</include>
+                <include>*.jar</include>
             </includes>
+             <outputDirectory>
+               BonitaCommunity-${branding.version}/server/webapps/bonita/WEB-INF/lib/
+            </outputDirectory>
         </fileSet>
     </fileSets>
     <dependencySets>

--- a/assemblies/src/main/resources/assemblies/bundle-tomcat-sp-assembly.xml
+++ b/assemblies/src/main/resources/assemblies/bundle-tomcat-sp-assembly.xml
@@ -7,20 +7,18 @@
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
-        <fileSet>
+    	<fileSet>
             <directory>${project.build.directory}/bundle</directory>
             <outputDirectory>.</outputDirectory>
-            <excludes>
-                <exclude>BonitaSubscription-${branding.version}/setup/platform_conf/initial/platform_engine/bonita-platform-community-custom.properties</exclude>
-            </excludes>
         </fileSet>
         <fileSet>
-            <directory>${project.build.directory}/bundle</directory>
-            <outputDirectory>.</outputDirectory>
-            <filtered>true</filtered>
+            <directory>${project.build.directory}/classpath</directory>
             <includes>
-                <include>BonitaSubscription-${branding.version}/setup/platform_conf/initial/platform_engine/bonita-platform-community-custom.properties</include>
+                <include>*.jar</include>
             </includes>
+            <outputDirectory>
+               BonitaSubscription-${branding.version}/server/webapps/bonita/WEB-INF/lib/
+            </outputDirectory>
         </fileSet>
     </fileSets>
     <dependencySets>

--- a/assemblies/src/main/resources/assemblies/classpath-assembly.xml
+++ b/assemblies/src/main/resources/assemblies/classpath-assembly.xml
@@ -1,0 +1,33 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>classpath</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <!-- Avoid empty assembly error by including the generated assembly file -->
+    <files>
+        <file>
+            <source>${project.build.directory}/classpath/classpath-assembly.xml</source>
+        </file>
+    </files>
+    <dependencySets>
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>*:jar</include>
+            </includes>
+            <excludes>
+                <exclude>*:zip</exclude>
+                <exclude>org.bonitasoft.engine:bonita-common</exclude>
+                <exclude>com.bonitasoft.engine:bonita-common-sp</exclude>
+                <exclude>org.bonitasoft.engine:bonita-server</exclude>
+                <exclude>com.bonitasoft.engine:bonita-server-sp</exclude>
+            </excludes>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/assemblies/src/main/resources/docker/Dockerfile
+++ b/assemblies/src/main/resources/docker/Dockerfile
@@ -3,8 +3,12 @@ FROM $BONITA_BASE_IMAGE
 
 ARG BONITA_CUSTOM_APPLICATION_FOLDER="my-application"
 ARG BONITA_WEB_INF_CLASSES_PATH="/opt/bonita/server/webapps/bonita/WEB-INF/classes"
+ARG BONITA_WEB_INF_LIB_PATH="/opt/bonita/server/webapps/bonita/WEB-INF/lib"
 ARG ARTIFACT_FINAL_NAME
 ARG BONITA_ENVIRONMENT=local
 
 # Copy bonita application resources (e.g. .zip and .bconf) to the dedicated bundle folder
 COPY --chown=bonita:bonita ${ARTIFACT_FINAL_NAME}-${BONITA_ENVIRONMENT}.* ${BONITA_WEB_INF_CLASSES_PATH}/${BONITA_CUSTOM_APPLICATION_FOLDER}/
+
+# Copy extra dependencies in webapp classpath
+COPY --chown=bonita:bonita classpath/*.jar ${BONITA_WEB_INF_LIB_PATH}/

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -296,6 +296,19 @@
                 </descriptorRefs>
               </configuration>
             </execution>
+            <!-- Assembly used to build the webapp classpath -->
+            <execution>
+              <id>application-classpath</id>
+              <phase>package</phase>
+              <configuration>
+                <attach>false</attach>
+                <finalName>classpath</finalName>
+                <appendAssemblyId>false</appendAssemblyId>
+                <descriptors>
+                  <descriptor>${project.build.directory}/classpath/classpath-assembly.xml</descriptor>
+                </descriptors>
+              </configuration>
+            </execution>
           </executions>
         </plugin>
         <plugin>
@@ -310,7 +323,13 @@
           <dependencies>
             <dependency>
               <groupId>org.codehaus.groovy</groupId>
-              <artifactId>groovy</artifactId>
+              <artifactId>groovy-json</artifactId>
+              <version>${groovy.version}</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>org.codehaus.groovy</groupId>
+              <artifactId>groovy-xml</artifactId>
               <version>${groovy.version}</version>
               <scope>runtime</scope>
             </dependency>
@@ -368,6 +387,51 @@
                       applicationProperties.each { it ->
                         out << it << System.lineSeparator()
                       }
+                    }
+                  ]]></script>
+                </scripts>
+              </configuration>
+            </execution>
+            <!-- Generate 'classpath-assembly.xml' file use to add additional dependencies in the webapp classpath -->
+            <execution>
+              <id>generate-classpath-assembly</id>
+              <phase>prepare-package</phase>
+              <configuration>
+                <scripts>
+                  <script><![CDATA[
+                    import groovy.json.JsonSlurper
+                    import groovy.xml.XmlSlurper
+                    import groovy.xml.XmlUtil 
+                    import org.slf4j.LoggerFactory                    
+                    
+                    def log = LoggerFactory.getLogger(getClass())
+                    def project = properties.project
+                    
+                    // Classpath assembly templating
+                    def classpathFolder = new File(project.build.directory, 'classpath')
+                    classpathFolder.mkdirs()
+                    def assemblyFile = new File(classpathFolder, 'classpath-assembly.xml')
+                    assemblyFile.createNewFile()
+                    def is = getClass().getResourceAsStream("/assemblies/${assemblyFile.name}")
+                    assemblyFile.append(is)
+                    is.close()
+                    
+                    def dependencyReportFile = new File(project.build.directory, 'bonita-dependencies.json')
+                    if(dependencyReportFile.exists()){
+                        def report = new JsonSlurper().parse(dependencyReportFile)
+                        // Excluding Bonita connectors and actor filters artifacts
+                        def implementations = report.connectorImplementations + report.filterImplementations
+                        def excludedArtifacts =  implementations.collect { impl -> "${impl.artifact.groupId}:${impl.artifact.artifactId}" }.unique()
+                        if(excludedArtifacts){
+                            def assembly = new XmlSlurper(false,false).parseText(assemblyFile.text)
+                            excludedArtifacts.each{ artifact ->
+                                assembly.dependencySets.dependencySet.excludes[0].appendNode{
+                                    log.info "Excluding $artifact from webapp classpath"
+                                    exclude(artifact)
+                                } 
+                            }
+                            assemblyFile.write(XmlUtil.serialize(assembly))
+                        }
                     }
                   ]]></script>
                 </scripts>

--- a/tests/src/it/package-bundle-tomcat/app/pom.xml
+++ b/tests/src/it/package-bundle-tomcat/app/pom.xml
@@ -9,6 +9,26 @@
     <version>1.0.0</version>
   </parent>
   <artifactId>my-project</artifactId>
+  <dependencies>
+       <!-- Should not be added in the webapp classpath (provided scope) -->
+      <dependency>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy</artifactId>
+        <scope>provided</scope>
+      </dependency>
+      <!-- Should be added in the webapp classpath -->
+      <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>42.6.0</version>
+      </dependency>
+      <!-- Should not be added in the webapp classpath (connector) -->
+      <dependency>
+        <groupId>org.bonitasoft.connectors</groupId>
+        <artifactId>bonita-connector-email</artifactId>
+        <version>1.3.0</version>
+      </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>
@@ -21,6 +41,27 @@
               <goal>execute</goal>
             </goals>
           </execution>
+          <execution>
+            <id>generate-classpath-assembly</id>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>bonita-project-maven-plugin</artifactId>
+        <groupId>org.bonitasoft.maven</groupId>
+        <executions>
+          <execution>
+            <id>process-bonita-artifacts</id>
+            <goals>
+              <goal>copy-provided-pages</goal>
+              <goal>business-archive</goal>
+              <goal>uid-page</goal>
+              <goal>merge-configuration</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -28,6 +69,12 @@
         <executions>
           <execution>
             <id>application-archive</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>application-classpath</id>
             <goals>
               <goal>single</goal>
             </goals>
@@ -48,18 +95,6 @@
                 <id>prepare-bundle</id>
                 <goals>
                   <goal>unpack</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-           <plugin>
-            <groupId>org.codehaus.gmavenplus</groupId>
-            <artifactId>gmavenplus-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>configure-bundle</id>
-                <goals>
-                  <goal>execute</goal>
                 </goals>
               </execution>
             </executions>

--- a/tests/src/it/package-bundle-tomcat/verify.groovy
+++ b/tests/src/it/package-bundle-tomcat/verify.groovy
@@ -2,3 +2,10 @@
 def file = new File(basedir, 'app/target/my-project-1.0.0-local-bundle.zip');
 assert file.exists(): 'Bundle Tomcat archive is missing'
 assert file.isFile(): 'Bundle Tomcat archive is not a normal file'
+
+// Assert webapp classpath contains declared dependencies
+def classpathFolder = new File(basedir, 'app/target/classpath/')
+assert classpathFolder.isDirectory() : 'classpath folder is missing'
+assert new File(classpathFolder, 'postgresql-42.6.0.jar').exists() : 'Postgresql driver dependency should be present in the webapp classpath'
+assert new File(classpathFolder, 'checker-qual-3.31.0.jar').exists() : 'Postgresql driver transitive dependency should be present in the webapp classpath'
+assert !new File(classpathFolder, 'bonita-connector-email-1.3.0.jar').exists() : 'bonita-connector-email should not be included in the webapp classpath'


### PR DESCRIPTION
Add an assembly to build a webapp level classpath. This classpath is the app module classpath without the bonita connector and actor filter included (and their transitive dependencies).

Once generated in the target/classpath folder of the app module, the jars of this folder are merged into the bonita/WEB-INF/lib folder of the webapp.