### PR TITLE
fix(classpath): handle empty classpath when building docker image

### DIFF
--- a/assemblies/src/main/resources/assemblies/classpath-assembly.xml
+++ b/assemblies/src/main/resources/assemblies/classpath-assembly.xml
@@ -6,12 +6,16 @@
         <format>dir</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
-    <!-- Avoid empty assembly error by including the generated assembly file -->
-    <files>
-        <file>
-            <source>${project.build.directory}/classpath/classpath-assembly.xml</source>
-        </file>
-    </files>
+    <!-- Avoid empty assembly error by including an empty folder -->
+    <fileSets>
+      <fileSet>
+          <directory>${project.basedir}/target</directory>
+          <outputDirectory>ignored-empty-folder</outputDirectory>
+          <excludes>
+              <exclude>*/**</exclude>
+          </excludes>
+      </fileSet>
+    </fileSets>
     <dependencySets>
         <dependencySet>
             <scope>runtime</scope>

--- a/assemblies/src/main/resources/docker/Dockerfile
+++ b/assemblies/src/main/resources/docker/Dockerfile
@@ -2,13 +2,12 @@ ARG BONITA_BASE_IMAGE=bonita:latest
 FROM $BONITA_BASE_IMAGE
 
 ARG BONITA_CUSTOM_APPLICATION_FOLDER="my-application"
-ARG BONITA_WEB_INF_CLASSES_PATH="/opt/bonita/server/webapps/bonita/WEB-INF/classes"
-ARG BONITA_WEB_INF_LIB_PATH="/opt/bonita/server/webapps/bonita/WEB-INF/lib"
+ARG BONITA_WEB_INF_PATH="/opt/bonita/server/webapps/bonita/WEB-INF"
 ARG ARTIFACT_FINAL_NAME
 ARG BONITA_ENVIRONMENT=local
 
 # Copy bonita application resources (e.g. .zip and .bconf) to the dedicated bundle folder
-COPY --chown=bonita:bonita ${ARTIFACT_FINAL_NAME}-${BONITA_ENVIRONMENT}.* ${BONITA_WEB_INF_CLASSES_PATH}/${BONITA_CUSTOM_APPLICATION_FOLDER}/
+COPY --chown=bonita:bonita ${ARTIFACT_FINAL_NAME}-${BONITA_ENVIRONMENT}.* ${BONITA_WEB_INF_PATH}/classes/${BONITA_CUSTOM_APPLICATION_FOLDER}/
 
 # Copy extra dependencies in webapp classpath
-COPY --chown=bonita:bonita classpath/*.jar ${BONITA_WEB_INF_LIB_PATH}/
+COPY --chown=bonita:bonita ./classpath/* ${BONITA_WEB_INF_PATH}/lib

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -305,7 +305,7 @@
                 <finalName>classpath</finalName>
                 <appendAssemblyId>false</appendAssemblyId>
                 <descriptors>
-                  <descriptor>${project.build.directory}/classpath/classpath-assembly.xml</descriptor>
+                  <descriptor>${project.build.directory}/assemblies/classpath-assembly.xml</descriptor>
                 </descriptors>
               </configuration>
             </execution>
@@ -408,9 +408,9 @@
                     def project = properties.project
                     
                     // Classpath assembly templating
-                    def classpathFolder = new File(project.build.directory, 'classpath')
-                    classpathFolder.mkdirs()
-                    def assemblyFile = new File(classpathFolder, 'classpath-assembly.xml')
+                    def assembliesFolder = new File(project.build.directory, 'assemblies')
+                    assembliesFolder.mkdirs()
+                    def assemblyFile = new File(assembliesFolder, 'classpath-assembly.xml')
                     assemblyFile.createNewFile()
                     def is = getClass().getResourceAsStream("/assemblies/${assemblyFile.name}")
                     assemblyFile.append(is)


### PR DESCRIPTION
Use an empty directory in the classpath-assembly
Use a wildcard pattern in the COPY stage of the image build

Related to DEV-551