### PR TITLE
fix(docker): add ending slash at the destination folder

### DIFF
--- a/assemblies/src/main/resources/docker/Dockerfile
+++ b/assemblies/src/main/resources/docker/Dockerfile
@@ -10,4 +10,4 @@ ARG BONITA_ENVIRONMENT=local
 COPY --chown=bonita:bonita ${ARTIFACT_FINAL_NAME}-${BONITA_ENVIRONMENT}.* ${BONITA_WEB_INF_PATH}/classes/${BONITA_CUSTOM_APPLICATION_FOLDER}/
 
 # Copy extra dependencies in webapp classpath
-COPY --chown=bonita:bonita ./classpath/* ${BONITA_WEB_INF_PATH}/lib
+COPY --chown=bonita:bonita ./classpath/* ${BONITA_WEB_INF_PATH}/lib/


### PR DESCRIPTION
Fix Docker error: `When using COPY with more than one source file, the destination must be a directory and end with a /`