### PR TITLE
fix(docker): Use a fresh Dockerfile between builds

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -481,11 +481,9 @@
                     // Copy resources from the bonita-project-assemblies resources jar
                     def resourceList = ['Dockerfile']
                     resourceList.each { name ->
-                      def file = new File(dockerOutput, name)
-                      file.createNewFile()
-                      def is = getClass().getResourceAsStream("/docker/$name")
-                      file.append(is)
-                      is.close()
+                      getClass().getResourceAsStream("/docker/$name").withCloseable { input ->
+                         java.nio.file.Files.copy(input, new File(dockerOutput, name).toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+                      }
                     }
                   ]]></script>
                 </scripts>


### PR DESCRIPTION
Make sure to use a clean version of the Dockerfile when building, even without using the `clean` maven goal.