### PR TITLE
ci(update-version): fix ignore conflicts mechanism

### DIFF
--- a/.github/workflows/_reusable_build.yml
+++ b/.github/workflows/_reusable_build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Reusable Build
 
 on:
   workflow_call:

--- a/.github/workflows/_reusable_update_version.yml
+++ b/.github/workflows/_reusable_update_version.yml
@@ -54,35 +54,10 @@ jobs:
           ./mvnw -ntp -f parent versions:set-property -Dproperty=branding.version -DnewVersion=${{ inputs.brandingVersion }}
           ./mvnw -ntp -f parent versions:set-property -Dproperty=bonita.runtime.version -DnewVersion=${{ inputs.version }}
 
+      # Add [ignore-conflicts] keyword to commit body message to be read by merge_upstream workflow
       - name: Commit and push changes
         run: |
-          git commit -a -m "chore(versioning): update version to ${{ inputs.brandingVersion }} (${{ inputs.version }})"
-          git push
-
-  merge-upstream:
-    needs: update-version
-    if: ${{ inputs.merge-upstream-ignoring-conflicts }}
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Setup git
-        uses: bonitasoft/git-setup-action@v1
-        with:
-          keeper-secret-config: ${{ secrets.KSM_CONFIG }}
-
-      - name: Determine upstream branch
-        id: upstream-branch
-        run: echo "ref=${{ fromJson(vars.SUPPORTED_BRANCHES).upstream-branch[github.ref_name] }}" >> $GITHUB_OUTPUT
-
-      - name: Checkout upstream branch
-        uses: actions/checkout@v4
-        with:
-          repository: bonitasoft/bonita-project
-          ref: ${{ steps.upstream-branch.outputs.ref }}
-          fetch-depth: 0
-          token: ${{ secrets.BONITA_CI_PAT }}
-
-      - name: Merge upstream branch
-        run: |
-          git config merge.ours.driver true
-          git merge origin/${{ github.ref_name }} -X ours  -m "chore(merge): ${{ github.ref_name }} into ${{ steps.upstream-branch.outputs.ref }}"
+          git commit -a \
+            -m "chore(versioning): update version to ${{ inputs.brandingVersion }} (${{ inputs.version }})" \
+            ${{ inputs.merge-upstream-ignoring-conflicts && '-m "[ignore-conflicts]"' || '' }}
           git push

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -12,7 +12,7 @@ on:
     paths-ignore:
       - '.github/**'
       - '**/README.md'
-      - '!.github/workflows/build.yml'
+      - '!.github/workflows/build-branch.yml'
       - '!.github/workflows/_reusable_build.yml'
 
 jobs:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,7 +1,12 @@
-name: Pull request
+name: Build Pull Request
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/**'
+      - '**/README.md'
+      - '!.github/workflows/build-pr.yml'
+      - '!.github/workflows/_reusable_build.yml'
 
 jobs:
   build-pr:

--- a/.github/workflows/merge_upstream.yml
+++ b/.github/workflows/merge_upstream.yml
@@ -1,14 +1,20 @@
+# This workflow merges changes from downstream branches to upstream branches.
+# If a commit contains [ignore-conflicts] in its message, conflicts will be
+# automatically resolved using the "ours" merge strategy.
 name: Merge Upstream
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   push:
-    branches: 
-      - '[0-9]+.[0-9]+.x'
-      - 'master'
-      - 'release-*'
+    branches:
+      - "[0-9]+.[0-9]+.x"
+      - "master"
+      - "release-*"
 
 jobs:
   merge-upstream:
     uses: bonitasoft/github-workflows/.github/workflows/_reusable_merge_upstream.yml@main
+    with:
+      # Ignore conflicts if the keyword [ignore-conflicts] is present in the commit message
+      ignore-conflicts: ${{ contains(github.event.head_commit.message, '[ignore-conflicts]') }}
     secrets: inherit


### PR DESCRIPTION
By committing the updated version modifications, it triggers the merge_upstream workflow automatically. The commit now contains a keyword to be detected by the merge_upstream workflow.

Related to issue https://github.com/bonitasoft/serenity/issues/217

:warning: **DO NOT MERGE THIS PR WITH THE KEYWORD IN THE MERGE COMMIT MESSAGE !!**