### PR TITLE
chore(ci): pin GitHub Actions to SHA for supply-chain security

### DIFF
--- a/.github/workflows/_reusable_build.yml
+++ b/.github/workflows/_reusable_build.yml
@@ -32,20 +32,20 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
           repository: bonitasoft/bonita-project
           token: ${{ secrets.BONITA_CI_PAT }}
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 17
           cache: maven
 
-      - uses: bonitasoft/maven-settings-action@v1
+      - uses: bonitasoft/maven-settings-action@3278c15e4023d52bc12da9d4e1a8b49a80b40559 # v1.4.0
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 
@@ -53,14 +53,14 @@ jobs:
         run: ./mvnw --no-transfer-progress -B verify -Ptests
 
       - name: Publish Test Report
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         if: always()
         with:
           files: |
             tests/**/target/*-reports/TEST-*.xml
 
       - name: Upload IT logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: it-logs

--- a/.github/workflows/_reusable_build.yml
+++ b/.github/workflows/_reusable_build.yml
@@ -45,7 +45,7 @@ jobs:
           java-version: 17
           cache: maven
 
-      - uses: bonitasoft/maven-settings-action@3278c15e4023d52bc12da9d4e1a8b49a80b40559 # v1.4.0
+      - uses: bonitasoft/maven-settings-action@v1
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 

--- a/.github/workflows/_reusable_tag.yml
+++ b/.github/workflows/_reusable_tag.yml
@@ -36,12 +36,12 @@ jobs:
           cache: maven
 
       - name: Setup Maven
-        uses: bonitasoft/maven-settings-action@3278c15e4023d52bc12da9d4e1a8b49a80b40559 # v1.4.0
+        uses: bonitasoft/maven-settings-action@v1
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 
       - name: Git Setup
-        uses: bonitasoft/git-setup-action@9593cf641830d8eadee52875d064ab6903b8b149 # v1.1.0
+        uses: bonitasoft/git-setup-action@v1
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 

--- a/.github/workflows/_reusable_tag.yml
+++ b/.github/workflows/_reusable_tag.yml
@@ -22,26 +22,26 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref }}
           repository: bonitasoft/bonita-project
           token: ${{ secrets.BONITA_CI_PAT }}
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 17
           cache: maven
 
       - name: Setup Maven
-        uses: bonitasoft/maven-settings-action@v1
+        uses: bonitasoft/maven-settings-action@3278c15e4023d52bc12da9d4e1a8b49a80b40559 # v1.4.0
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 
       - name: Git Setup
-        uses: bonitasoft/git-setup-action@v1
+        uses: bonitasoft/git-setup-action@9593cf641830d8eadee52875d064ab6903b8b149 # v1.1.0
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 

--- a/.github/workflows/_reusable_update_version.yml
+++ b/.github/workflows/_reusable_update_version.yml
@@ -39,12 +39,12 @@ jobs:
           cache: maven
 
       - name: Setup Maven
-        uses: bonitasoft/maven-settings-action@3278c15e4023d52bc12da9d4e1a8b49a80b40559 # v1.4.0
+        uses: bonitasoft/maven-settings-action@v1
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 
       - name: Git Setup
-        uses: bonitasoft/git-setup-action@9593cf641830d8eadee52875d064ab6903b8b149 # v1.1.0
+        uses: bonitasoft/git-setup-action@v1
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 

--- a/.github/workflows/_reusable_update_version.yml
+++ b/.github/workflows/_reusable_update_version.yml
@@ -25,26 +25,26 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref }}
           repository: bonitasoft/bonita-project
           token: ${{ secrets.BONITA_CI_PAT }}
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 17
           cache: maven
 
       - name: Setup Maven
-        uses: bonitasoft/maven-settings-action@v1
+        uses: bonitasoft/maven-settings-action@3278c15e4023d52bc12da9d4e1a8b49a80b40559 # v1.4.0
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 
       - name: Git Setup
-        uses: bonitasoft/git-setup-action@v1
+        uses: bonitasoft/git-setup-action@9593cf641830d8eadee52875d064ab6903b8b149 # v1.1.0
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 

--- a/.github/workflows/merge_upstream.yml
+++ b/.github/workflows/merge_upstream.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   merge-upstream:
-    uses: bonitasoft/github-workflows/.github/workflows/_reusable_merge_upstream.yml@main
+    uses: bonitasoft/github-workflows/.github/workflows/_reusable_merge_upstream.yml@e56989fa572db79504e96006dabfbe917b1987ee # main
     with:
       # Ignore conflicts if the keyword [ignore-conflicts] is present in the commit message
       ignore-conflicts: ${{ contains(github.event.head_commit.message, '[ignore-conflicts]') }}

--- a/.github/workflows/merge_upstream.yml
+++ b/.github/workflows/merge_upstream.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   merge-upstream:
-    uses: bonitasoft/github-workflows/.github/workflows/_reusable_merge_upstream.yml@e56989fa572db79504e96006dabfbe917b1987ee # main
+    uses: bonitasoft/github-workflows/.github/workflows/_reusable_merge_upstream.yml@main
     with:
       # Ignore conflicts if the keyword [ignore-conflicts] is present in the commit message
       ignore-conflicts: ${{ contains(github.event.head_commit.message, '[ignore-conflicts]') }}


### PR DESCRIPTION
## Summary

- Pin third-party GitHub Action references to full 40-character commit SHAs
- Add complete version tag comments for traceability (e.g., `# v6.0.2`)
- Bonitasoft org actions are kept as tag refs (managed internally)

## Changes

| Action | Old Ref | SHA | Version |
|---|---|---|---|
| `actions/checkout` | `v6` | `de0fac2e...` | `v6.0.2` |
| `actions/setup-java` | `v5` | `be666c2f...` | `v5.2.0` |
| `EnricoMi/publish-unit-test-result-action` | `v2` | `c950f6fb...` | `v2.23.0` |
| `actions/upload-artifact` | `v7` | `bbbca2dd...` | `v7.0.0` |

## Files modified

- `_reusable_build.yml` — 4 actions pinned
- `_reusable_tag.yml` — 2 actions pinned
- `_reusable_update_version.yml` — 2 actions pinned

## Test plan

- [x] Verify CI build passes with SHA-pinned references

🤖 Generated with [Claude Code](https://claude.com/claude-code)