### PR TITLE
chore(dependencies): Downgrade maven-jar-plugin to 3.4.2 in parent POM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,6 @@ updates:
       - dependency-name: "*maven-install-plugin*"
       # Ignore maven-assembly-plugin updates until this issue is fixed: https://github.com/apache/maven-assembly-plugin/issues/1236
       - dependency-name: "*maven-assembly-plugin*"
+      # Skip maven-jar-plugin 3.5.x due to Guice incompatibility (BPA-427)
+      - dependency-name: "*maven-jar-plugin*"
+        versions: ["3.5.x"]

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <!-- The version of maven-install-plugin should follow the one of bonita-project-maven-plugin -->
     <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
-    <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>


### PR DESCRIPTION
## Summary

The previous downgrade (#270) only updated the **root aggregator** `pom.xml`, but downstream Bonita Projects inherit from `parent/pom.xml` — which was still pinning `maven-jar-plugin` to `3.5.0`. As a result, the Guice incompatibility remained unresolved for consumers of the parent POM.

This PR:
- Aligns `parent/pom.xml` with the root aggregator (`3.5.0` → `3.4.2`)
- Adds a dependabot ignore rule for `maven-jar-plugin` `3.5.x` so the problematic version isn't re-proposed (future `3.6.x+` upgrades will still flow through automatically)

Relates to [BPA-427](https://bonitasoft.atlassian.net/browse/BPA-427)

## Test plan

- [ ] CI green on `./mvnw --no-transfer-progress -B verify -Ptests`
- [ ] Downstream Bonita Project pulling the new parent POM snapshot resolves `maven-jar-plugin` to `3.4.2`

[BPA-427]: https://bonitasoft.atlassian.net/browse/BPA-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ