### PR TITLE
chore(dependencies): Restore maven-jar-plugin 3.4.2 and fix dependabot ignore syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,6 @@ updates:
       - dependency-name: "*maven-install-plugin*"
       # Ignore maven-assembly-plugin updates until this issue is fixed: https://github.com/apache/maven-assembly-plugin/issues/1236
       - dependency-name: "*maven-assembly-plugin*"
-      # Skip maven-jar-plugin 3.5.x due to Guice incompatibility (BPA-427)
+      # Skip maven-jar-plugin 3.5.0+ due to Guice incompatibility (BPA-427)
       - dependency-name: "*maven-jar-plugin*"
-        versions: ["[3.5.0,3.6.0)"]
+        versions: ["[3.5.0,)"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,4 +35,4 @@ updates:
       - dependency-name: "*maven-assembly-plugin*"
       # Skip maven-jar-plugin 3.5.x due to Guice incompatibility (BPA-427)
       - dependency-name: "*maven-jar-plugin*"
-        versions: ["3.5.x"]
+        versions: ["[3.5.0,3.6.0)"]

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <!-- The version of maven-install-plugin should follow the one of bonita-project-maven-plugin -->
     <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
-    <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
     <!-- The version of maven-install-plugin should follow the one of bonita-project-maven-plugin -->
     <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
-    <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>


### PR DESCRIPTION
## Summary

PR #273 added a dependabot ignore rule for `maven-jar-plugin 3.5.x`, but it used npm-style wildcards (`"3.5.x"`) which are **not valid** for the Maven ecosystem. Dependabot silently treated the rule as a no-op, and #284 went on to merge the `3.4.2 → 3.5.0` bump anyway.

This PR:
- Re-downgrades `maven-jar-plugin` to `3.4.2` in both `pom.xml` (root aggregator) and `parent/pom.xml` (the parent POM consumed by downstream Bonita Projects)
- Replaces the invalid `versions: ["3.5.x"]` with Maven range syntax `versions: ["[3.5.0,)"]`, which correctly blocks any `3.5.x` release

Per [GitHub's Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference), the Maven ecosystem expects bracket-notation ranges (e.g. `[1.4,)`).

Relates to [BPA-427](https://bonitasoft.atlassian.net/browse/BPA-427)

## Test plan

- [ ] CI green on `./mvnw --no-transfer-progress -B verify -Ptests`
- [ ] After merge, no new dependabot PR proposing `maven-jar-plugin 3.5.x`
- [ ] Downstream Bonita Project pulling the new parent POM snapshot resolves `maven-jar-plugin` to `3.4.2`

Relates to [BPA-427](https://bonitasoft.atlassian.net/browse/BPA-427)
Covers [BPA-500](https://bonitasoft.atlassian.net/browse/BPA-500)

[BPA-427]: https://bonitasoft.atlassian.net/browse/BPA-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BPA-427]: https://bonitasoft.atlassian.net/browse/BPA-427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ