### PR TITLE
fix: manage bonita-user-application-sp version in dependencyManagement

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -96,6 +96,13 @@
         <type>zip</type>
       </dependency>
       <dependency>
+        <groupId>com.bonitasoft.web.application</groupId>
+        <artifactId>bonita-user-application-sp</artifactId>
+        <version>${bonita.runtime.version}</version>
+        <classifier>application</classifier>
+        <type>zip</type>
+      </dependency>
+      <dependency>
         <groupId>com.bonitasoft</groupId>
         <artifactId>bonita-test-toolkit</artifactId>
         <version>${bonita-test-toolkit.version}</version>


### PR DESCRIPTION
## Problem

Installing the **Bonita User Application Enterprise** (`com.bonitasoft.web.application:bonita-user-application-sp`) from the Studio marketplace results in a `null` version, while the Enterprise admin app resolves correctly.

Studio installs application-type extensions **without an explicit `<version>`** (the marketplace descriptor gives them an empty version), relying on the `dependencyManagement` inherited from this parent POM to supply the version. `bonita-admin-application-sp` is managed here; `bonita-user-application-sp` was missing, so Maven could not resolve its version.

## Fix

Add `com.bonitasoft.web.application:bonita-user-application-sp` to `parent/pom.xml` `dependencyManagement`, mirroring the existing `bonita-admin-application-sp` entry (version `${bonita.runtime.version}`, classifier `application`, type `zip`).

## Related

Studio-side support (the `BonitaUserAppDependency` class + community-to-enterprise migration) is in bonitasoft/bonita-studio-sp#3917. This PR is the piece that makes the installed user-app SP dependency resolve to a real version.

Requires that `bonita-user-application-sp` is published at `${bonita.runtime.version}`.