### PR TITLE
chore(deps): align maven-install-plugin with bonita-project-maven-plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -15,7 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>17</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
-    <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
+    <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>


### PR DESCRIPTION
Bump to 3.1.3 according to bonita-project-maven-plugin 2.1.3 (see https://github.com/bonitasoft/bonita-project-maven-plugin/blob/2.1.3/plugin/src/main/java/org/bonitasoft/plugin/install/InstallProjectStoreMojo.java#L87)