### PR TITLE
chore(deps): sync Groovy 4.0.32 with the bonita runtime

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -56,6 +56,9 @@
     <include.processes>*.bar</include.processes>
     <include.pages>*.zip</include.pages>
     <groovy.repository.url>https://groovy.jfrog.io/artifactory/plugins-release/</groovy.repository.url>
+    <!-- groovy-eclipse-batch embeds the Groovy compiler and must match the groovy.version line;
+         groovy-eclipse-compiler is the maven compiler ADAPTER - its version is independent of the
+         Groovy language line (the adapter is level-agnostic) -->
     <groovy-eclipse-batch.version>4.0.32-01</groovy-eclipse-batch.version>
     <groovy-eclipse-compiler.version>3.9.0</groovy-eclipse-compiler.version>
   </properties>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -387,7 +387,6 @@
           <configuration>
             <bindAllProjectProperties>true</bindAllProjectProperties>
             <bindAllSessionUserProperties>true</bindAllSessionUserProperties>
-            <bindPropertiesToSeparateVariables>false</bindPropertiesToSeparateVariables>
           </configuration>
           <dependencies>
             <dependency>
@@ -429,8 +428,8 @@
               <configuration>
                 <scripts>
                   <script><![CDATA[
-                    def project = properties.project
-                    def environment = properties.'bonita.environment'
+                    def project = binding.variables.project
+                    def environment = binding.variables.'bonita.environment'
                     lcBonitaEnv = environment == null ? 'local' : environment.toLowerCase()
                     project.properties.setProperty('bonita.environment:lowercase', lcBonitaEnv)
                     project.properties.setProperty('project.artifactId:lowercase', project.artifactId.toLowerCase())
@@ -445,7 +444,7 @@
               <configuration>
                 <scripts>
                   <script><![CDATA[
-                    def project = properties.project
+                    def project = binding.variables.project
                     def propsFile = new File(project.build.directory, 'application.properties')
                     propsFile.delete()
                     propsFile.getParentFile().mkdirs()
@@ -474,7 +473,7 @@
                     import org.slf4j.LoggerFactory                    
                     
                     def log = LoggerFactory.getLogger(getClass())
-                    def project = properties.project
+                    def project = binding.variables.project
                     
                     // Classpath assembly templating
                     def assembliesFolder = new File(project.build.directory, 'assemblies')
@@ -492,7 +491,7 @@
                      * They used to be in the bar, but are not in the jarless bar.
                      * So they are now directly included in the webapp classpath.
                      */
-                    def barHasJars = properties.'bonita.includeDependencyJars' == null || properties.'bonita.includeDependencyJars'.toBoolean()
+                    def barHasJars = binding.variables.'bonita.includeDependencyJars' == null || binding.variables.'bonita.includeDependencyJars'.toBoolean()
                     if(barHasJars){
                         def dependencyReportFile = new File(project.build.directory, 'bonita-dependencies.json')
                         if(dependencyReportFile.exists()){
@@ -523,7 +522,7 @@
               <configuration>
                 <scripts>
                   <script><![CDATA[
-                    def dockerOutput = new File(properties.project.build.directory)
+                    def dockerOutput = new File(binding.variables.project.build.directory)
                     dockerOutput.mkdirs()
 
                     // Copy resources from the bonita-project-assemblies resources jar

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -38,7 +38,7 @@
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
     <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
     <!-- Should match version in bonita-runtime-bom -->
-    <groovy.version>3.0.25</groovy.version>
+    <groovy.version>4.0.32</groovy.version>
     <!-- Bonita specific properties below -->
     <bonita.environment>local</bonita.environment>
     <!-- DO NOT USE ${project.version} or ${project.parent.version} here -->
@@ -56,7 +56,7 @@
     <include.processes>*.bar</include.processes>
     <include.pages>*.zip</include.pages>
     <groovy.repository.url>https://groovy.jfrog.io/artifactory/plugins-release/</groovy.repository.url>
-    <groovy-eclipse-batch.version>3.0.23-02</groovy-eclipse-batch.version>
+    <groovy-eclipse-batch.version>4.0.32-01</groovy-eclipse-batch.version>
     <groovy-eclipse-compiler.version>3.9.0</groovy-eclipse-compiler.version>
   </properties>
   <dependencyManagement>
@@ -69,7 +69,7 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId>
+        <groupId>org.apache.groovy</groupId>
         <artifactId>groovy-all</artifactId>
         <version>${groovy.version}</version>
         <type>pom</type>
@@ -160,6 +160,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
           <dependencies>
+            <!-- the groovy-eclipse artifacts keep the org.codehaus.groovy groupId even for
+                 Groovy 4 (the groovy-eclipse project never moved to org.apache.groovy) -->
             <dependency>
               <groupId>org.codehaus.groovy</groupId>
               <artifactId>groovy-eclipse-compiler</artifactId>
@@ -389,19 +391,19 @@
           </configuration>
           <dependencies>
             <dependency>
-              <groupId>org.codehaus.groovy</groupId>
+              <groupId>org.apache.groovy</groupId>
               <artifactId>groovy-json</artifactId>
               <version>${groovy.version}</version>
               <scope>runtime</scope>
             </dependency>
             <dependency>
-              <groupId>org.codehaus.groovy</groupId>
+              <groupId>org.apache.groovy</groupId>
               <artifactId>groovy-xml</artifactId>
               <version>${groovy.version}</version>
               <scope>runtime</scope>
             </dependency>
             <dependency>
-              <groupId>org.codehaus.groovy</groupId>
+              <groupId>org.apache.groovy</groupId>
               <artifactId>groovy-ant</artifactId>
               <version>${groovy.version}</version>
               <scope>runtime</scope>

--- a/tests/src/it/package-bundle-tomcat-jarless/app/pom.xml
+++ b/tests/src/it/package-bundle-tomcat-jarless/app/pom.xml
@@ -12,7 +12,7 @@
   <dependencies>
        <!-- Should not be added in the webapp classpath (provided scope) -->
       <dependency>
-        <groupId>org.codehaus.groovy</groupId>
+        <groupId>org.apache.groovy</groupId>
         <artifactId>groovy</artifactId>
         <scope>provided</scope>
       </dependency>

--- a/tests/src/it/package-bundle-tomcat/app/pom.xml
+++ b/tests/src/it/package-bundle-tomcat/app/pom.xml
@@ -12,7 +12,7 @@
   <dependencies>
        <!-- Should not be added in the webapp classpath (provided scope) -->
       <dependency>
-        <groupId>org.codehaus.groovy</groupId>
+        <groupId>org.apache.groovy</groupId>
         <artifactId>groovy</artifactId>
         <scope>provided</scope>
       </dependency>


### PR DESCRIPTION
## What

Mirrors the engine's Groovy 3.0.25 -> 4.0.32 upgrade (bonitasoft/bonita-engine-sp#4033, merged on 12.0.x) in the customer-project parent pom - the sync that PR explicitly called for. The runtime BOM now manages the Groovy modules under the org.apache.groovy coordinates only.

## Changes

- `groovy.version` 3.0.25 -> **4.0.32** (the property's own comment requires matching bonita-runtime-bom)
- Language artifacts move to the Groovy 4 **org.apache.groovy** coordinates: the managed `groovy-all`, and the gmavenplus runtime additions (`groovy-json`/`groovy-xml`/`groovy-ant`)
- `groovy-eclipse-batch` 3.0.23-02 -> **4.0.32-01**: the batch compiler embeds the Groovy compiler and must match the language line; the exact 4.0.32 build exists on the Groovy artifactory. `groovy-eclipse-compiler` stays at 3.9.0, and both groovy-eclipse artifacts deliberately keep the **org.codehaus.groovy** groupId - that project never moved coordinates (inline comment added so the mixed groupIds do not get 'fixed' later)
- IT fixture apps (`package-bundle-tomcat`, `package-bundle-tomcat-jarless`): `org.codehaus.groovy:groovy` -> `org.apache.groovy:groovy` - the dependency is unversioned and resolved through the imported runtime BOM, which only manages the new coordinates (the old ones would no longer resolve a version)

## Customer impact (release notes)

Customer projects built with this parent inherit the Groovy 4 toolchain: groovy-eclipse-batch 4.x compiles their Groovy sources as Groovy 4, and org.codehaus.groovy dependencies in their own poms should move to org.apache.groovy. This pairs with the engine-side release-note items already collected for the 2027.1 migration guide (Groovy 4 runtime, groovy-servlet removal).

## Verification

- `./mvnw clean install` green against the 12.0-SNAPSHOT runtime
- groovy-eclipse-batch 4.0.32-01 presence verified on the Groovy artifactory (the pluginRepository already declared in this pom)
- The invoker ITs exercise the fixture poms against the runtime BOM in CI