### PR TITLE
chore(deps): adopt the jakarta generation of artifacts-model, artifact-builder and process-model

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -47,7 +47,7 @@
     <bonita-artifacts-model.version>2.0.1</bonita-artifacts-model.version>
     <ui-designer-artifact-builder.version>2.0.0</ui-designer-artifact-builder.version>
     <bonita-process-model.version>10.0.1</bonita-process-model.version>
-    <bonita-project-maven-plugin.version>2.2.0</bonita-project-maven-plugin.version>
+    <bonita-project-maven-plugin.version>3.0.0</bonita-project-maven-plugin.version>
     <bonita-test-toolkit.version>3.0.0</bonita-test-toolkit.version>
     <!-- Default inclusion filters -->
     <include.organizations>*.xml</include.organizations>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -47,7 +47,7 @@
     <bonita-artifacts-model.version>2.0.1</bonita-artifacts-model.version>
     <ui-designer-artifact-builder.version>2.0.0</ui-designer-artifact-builder.version>
     <bonita-process-model.version>10.0.1</bonita-process-model.version>
-    <bonita-project-maven-plugin.version>2.1.4</bonita-project-maven-plugin.version>
+    <bonita-project-maven-plugin.version>2.2.0</bonita-project-maven-plugin.version>
     <bonita-test-toolkit.version>3.0.0</bonita-test-toolkit.version>
     <!-- Default inclusion filters -->
     <include.organizations>*.xml</include.organizations>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -44,9 +44,9 @@
     <!-- DO NOT USE ${project.version} or ${project.parent.version} here -->
     <bonita.runtime.version>12.0-SNAPSHOT</bonita.runtime.version>
     <branding.version>2027.1-SNAPSHOT</branding.version>
-    <bonita-artifacts-model.version>1.2.2</bonita-artifacts-model.version>
-    <ui-designer-artifact-builder.version>1.0.10</ui-designer-artifact-builder.version>
-    <bonita-process-model.version>9.0.9</bonita-process-model.version>
+    <bonita-artifacts-model.version>2.0.1</bonita-artifacts-model.version>
+    <ui-designer-artifact-builder.version>2.0.0</ui-designer-artifact-builder.version>
+    <bonita-process-model.version>10.0.1</bonita-process-model.version>
     <bonita-project-maven-plugin.version>2.1.4</bonita-project-maven-plugin.version>
     <bonita-test-toolkit.version>3.0.0</bonita-test-toolkit.version>
     <!-- Default inclusion filters -->


### PR DESCRIPTION
## What

Moves the project parent to the jakarta generation of the Bonita toolchain:

| Property | From | To | Status |
|---|---|---|---|
| `bonita-artifacts-model.version` | 1.2.2 | **2.0.1** | released (jakarta.xml.bind - same version as the engine 12.0 stack) |
| `ui-designer-artifact-builder.version` | 1.0.10 | **2.0.0** | released (jakarta validation/EL stack, Spring Boot 3.5 BOM) |
| `bonita-process-model.version` | 9.0.9 | **10.0.1** | released (Groovy 4 toolchain line) |
| `bonita-project-maven-plugin.version` | 2.1.4 | **3.0.0** | pending release (bonitasoft/bonita-project-maven-plugin#524, green on the full jakarta stack; ships as a new major because the plugin realm swaps the javax-generation validation/EL stack for jakarta - breaking for consumers extending the plugin classpath) |

The plugin bump is required, not optional: injecting jakarta-generation jars into the javax-built 2.1.4 realm produces a mixed-generation classpath (see diagnosis below).

## Why

Part of the Jakarta migration (epic [BPA-230](https://bonitasoft.atlassian.net/browse/BPA-230)): aligns the customer-project toolchain with the engine 12.0 runtime. Groovy 4 BAR compilation comes with bonita2bar 10.0.1; the jakarta Bean Validation/EL stack (validation-api 3.x, Hibernate Validator 8, expressly) comes with artifact-builder 2.0.0.

## Current CI state and remaining gates

The packaging ITs (`package-bundle-tomcat*`, `application-archive`, `package-docker-image`) fail with `NoClassDefFoundError: jakarta/validation/Validation` in the plugin realm. Root-cause analysis (full details in [this comment](https://github.com/bonitasoft/bonita-project/pull/371#issuecomment-5206929899)):

1. **Stale engine snapshot**: the `12.0-SNAPSHOT` on artifactory predates bonitasoft/bonita-engine-sp#4034 (last publish 2026-08-03) and drags the Boot 2.7-era `hibernate-validator 6.2.5` / `jakarta.validation-api 2.0.2` (javax packages) pair into the plugin realm via `bonita-business-data-generator`. **Gate: trigger a `12.0.x` engine build so a post-Wave-C snapshot publishes.**
2. **Plugin release**: `bonita-project-maven-plugin` **3.0.0** must be released from the #524 line. **Gate: merge #524, release as 3.0.0.**

Once both are done, rerun this PR's CI; the draft flips to ready on green.

## Related

- bonitasoft/bonita-project-maven-plugin#524 (plugin side of the same bumps)
- bonitasoft/bonita-ui-designer-internal#630 (UID side, artifact-builder 2.0.0 adoption on the 1.21.0 line)


[BPA-230]: https://bonitasoft.atlassian.net/browse/BPA-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ