### PR TITLE
fix(deps): import the groovy-bom to manage all org.apache.groovy modules [BPA-761]

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,11 +71,15 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- imports the management of every org.apache.groovy module, so consumer projects can
+           declare groovy modules without a version (a plain managed groovy-all entry only pins
+           a literal groovy-all dependency and manages nothing else) -->
       <dependency>
         <groupId>org.apache.groovy</groupId>
-        <artifactId>groovy-all</artifactId>
+        <artifactId>groovy-bom</artifactId>
         <version>${groovy.version}</version>
         <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.bonitasoft.web.application</groupId>


### PR DESCRIPTION
## What

Replaces the plain managed `org.apache.groovy:groovy-all` (type pom) entry in the parent's `dependencyManagement` with a proper `org.apache.groovy:groovy-bom` **import** at `${groovy.version}` (4.0.32).

## Why

A managed `groovy-all` entry without `scope=import` only pins a literal `groovy-all` dependency - it manages none of the individual Groovy modules. Bonita Studio user projects declare 12 `org.apache.groovy` modules at provided scope (groovy, groovy-json, groovy-xml, groovy-nio, groovy-datetime, groovy-dateutil, groovy-sql, groovy-templates, groovy-jsr223, groovy-jmx, groovy-yaml), and since the jakarta `bonita-runtime-bom` dropped its groovy management, those versionless dependencies fail to resolve:

```
'dependencies.dependency.version' for org.codehaus.groovy:groovy:jar is missing
```

(observed with the pre-Groovy-4 coordinates in bonita-studio-sp CI; the Studio currently works around it with explicit 4.0.32 pins tagged `TODO(BPA-761)` in its template poms and project scaffolding - see bonitasoft/bonita-studio-sp#3944 and bonitasoft/bonita-studio-sp#3950.)

The `groovy-bom` import manages every module at `${groovy.version}` - including `groovy-all` itself, so the previous entry's effect is preserved. Once released, the Studio-side pins and its own `groovy-bom` imports can be removed (the BPA-761 cleanup).

## Tracking

[BPA-761](https://bonitasoft.atlassian.net/browse/BPA-761) (Groovy 4 alignment, under epic [BPA-230](https://bonitasoft.atlassian.net/browse/BPA-230)).

[BPA-761]: https://bonitasoft.atlassian.net/browse/BPA-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ